### PR TITLE
conf: updated tsconfig (typeRoots)

### DIFF
--- a/common/tsconfig.json
+++ b/common/tsconfig.json
@@ -10,7 +10,6 @@
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "node",
     "lib": ["es2018", "dom", "esnext.asynciterable"],
-    "typeRoots": ["./custom_typings"],
     "types": ["jest"]
   },
   "paths": {


### PR DESCRIPTION
Sets `typeRoots` to default: all visible `@types` packages

- with the previous setting `node_modules/**/@types` were ignored
- `./custom_typings/*` gets registered simply because of being inside `include`.

Generally the typeRoots directive is meant for something different:
https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#types-typeroots-and-types
(briefly: for location with custom type packages, not just a dir with custom typings)

Actual problem this causes: typedefs for jest's global functions not found when running test scripts (because there is no `custom_typings/jest`).