### PR TITLE
hotfix(common > eslint): breaking change in lib

### DIFF
--- a/common/.eslintrc.js
+++ b/common/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
   },
   extends: [
     'plugin:@typescript-eslint/recommended',
-    'prettier/@typescript-eslint',
+    'prettier',
     'plugin:prettier/recommended',
   ],
   ignorePatterns: ['node_modules/*', '/tests/**'],


### PR DESCRIPTION
- `prettier/@typescript-eslint` should be replaced with `prettier` because of the following breaking change:
https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21

currently throws an error:
```
Cannot read config file: .../node_modules/eslint-config-prettier/@typescript-eslint.js
Error: "prettier/@typescript-eslint" has been merged into "prettier" in eslint-config-prettier 8.0.0. See: https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21
```